### PR TITLE
Add back Terms of Service section

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -1,3 +1,10 @@
+___TERMS_OF_SERVICE___
+
+By creating or modifying this file you agree to Google Tag Manager's Community
+Template Gallery Developer Terms of Service available at
+https://developers.google.com/tag-manager/gallery-tos (or such other URL as
+Google may provide), as modified from time to time.
+
 ___INFO___
 
 {


### PR DESCRIPTION
This PR adds back the Terms of Service section that was removed in commit 793ebf27734c671074536f6be3542b187b647d35. The section includes the required Google Tag Manager Community Template Gallery Developer Terms of Service reference.